### PR TITLE
Remove duplication of style definitions

### DIFF
--- a/src/components/Dropdown.vue
+++ b/src/components/Dropdown.vue
@@ -22,7 +22,6 @@
 </script>
 
 <style lang="scss" scoped>
-  @import "../styles/base";
 .aggregator__dropdown{
   display: inline-block;
   margin: unset;

--- a/src/components/Retip.vue
+++ b/src/components/Retip.vue
@@ -91,7 +91,6 @@
 </script>
 
 <style lang="scss" scoped>
- @import "../styles/base";
   .overlay{
     position: fixed;
     top: 0;

--- a/src/components/layout/LeftSection.vue
+++ b/src/components/layout/LeftSection.vue
@@ -119,7 +119,7 @@
   }
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
   .app__leftcolumn {
     color: $standard_font_color;
     display: inline-block;

--- a/src/components/layout/LeftSection.vue
+++ b/src/components/layout/LeftSection.vue
@@ -60,7 +60,7 @@
           <div class="overview__label">
             Unique Tip Senders
           </div>
-        </div> 
+        </div>
         <div class="overview__item" v-if="stats.total_amount">
           <div class="overview__value secondary">
             {{stats.total_amount}}
@@ -119,9 +119,7 @@
   }
 </script>
 
-<style lang="scss">
-  @import "../../styles/base";
-
+<style lang="scss" scoped>
   .app__leftcolumn {
     color: $standard_font_color;
     display: inline-block;
@@ -143,7 +141,7 @@
             cursor: pointer;
           }
         }
-      } 
+      }
       .navigation {
         margin-bottom: 1rem;
         font-weight: 500;
@@ -235,7 +233,7 @@
     margin-bottom: 1.15rem;
     font-weight: 400;
   }
-} 
+}
 
 }
 </style>

--- a/src/components/layout/RightSection.vue
+++ b/src/components/layout/RightSection.vue
@@ -80,8 +80,6 @@
 </script>
 
 <style lang="scss" scoped>
-  @import "../../styles/base";
-
   .topics-section{
     max-height: 0;
     transition: max-height 0.25s ease-in;

--- a/src/components/layout/SendTip.vue
+++ b/src/components/layout/SendTip.vue
@@ -74,8 +74,6 @@
 </script>
 
 <style lang="scss" scoped>
-  @import "../../styles/base";
-
   .tip__post {
     background-color: $actions_ribbon_background_color;
     max-height: 0;

--- a/src/components/tipRecords/TipComment.vue
+++ b/src/components/tipRecords/TipComment.vue
@@ -37,7 +37,6 @@
 
 
 <style lang="scss" scoped>
-  @import "../../styles/base";
   .comment.tip__record{
     padding-bottom: 0;
     margin-bottom: .5rem;

--- a/src/components/tipRecords/TipComment.vue
+++ b/src/components/tipRecords/TipComment.vue
@@ -36,7 +36,7 @@
 </script>
 
 
-<style lang="scss" scoped>
+<style lang="scss">
   .comment.tip__record{
     padding-bottom: 0;
     margin-bottom: .5rem;

--- a/src/components/tipRecords/TipRecord.vue
+++ b/src/components/tipRecords/TipRecord.vue
@@ -93,7 +93,7 @@
   }
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
   .tip__record.row.row{
     margin-left: 0;
     margin-right: 0;

--- a/src/components/tipRecords/TipRecord.vue
+++ b/src/components/tipRecords/TipRecord.vue
@@ -93,9 +93,7 @@
   }
 </script>
 
-<style lang="scss" >
- @import "../../styles/base";
-
+<style lang="scss" scoped>
   .tip__record.row.row{
     margin-left: 0;
     margin-right: 0;

--- a/src/components/tipRecords/TipTitle.vue
+++ b/src/components/tipRecords/TipTitle.vue
@@ -31,7 +31,7 @@
   }
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
   .title {
     display: inline;
 

--- a/src/components/tipRecords/TipTitle.vue
+++ b/src/components/tipRecords/TipTitle.vue
@@ -31,9 +31,7 @@
   }
 </script>
 
-<style lang="scss">
-  @import "../../styles/base";
-
+<style lang="scss" scoped>
   .title {
     display: inline;
 

--- a/src/components/tipRecords/Topic.vue
+++ b/src/components/tipRecords/Topic.vue
@@ -23,9 +23,7 @@
   }
 </script>
 
-<style lang="scss">
-  @import "../../styles/base";
-
+<style lang="scss" scoped>
   .topic{
     color: #67B6F7;
     &:hover{

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -1,3 +1,5 @@
+// This file is included multiple times in every scss file and component, do not put any rendered styles
+
 @mixin vertical-align($position: relative) {
   position: $position;
   top: 50%;

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,3 +1,5 @@
+// This file is included multiple times in every scss file and component, do not put any rendered styles
+
 //  $primary_color: #5F4191;//#FF0D6A;
 //  $secondary_color: #FF0D6A;
 //  $light_color: #EFEFEF;

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -1,6 +1,3 @@
-@import "variables";
-@import "mixins";
-
 //Bootstrap customizations go here:
 $theme-colors: (
   "primary": $primary_color,

--- a/src/views/CreateProfile.vue
+++ b/src/views/CreateProfile.vue
@@ -269,8 +269,6 @@
 
 
 <style lang="scss" scoped>
-  @import "../styles/base";
-
   .content {
     color: $standard_font_color;
   }

--- a/src/views/Mission.vue
+++ b/src/views/Mission.vue
@@ -48,8 +48,6 @@
 
 
 <style lang="scss" scoped>
-  @import "../styles/base";
-
   .content {
     color: $primary_color;
   }

--- a/src/views/Privacy.vue
+++ b/src/views/Privacy.vue
@@ -112,8 +112,6 @@
 
 
 <style lang="scss" scoped>
-  @import "../styles/base";
-
   .content {
     color: $primary_color;
   }

--- a/src/views/Terms.vue
+++ b/src/views/Terms.vue
@@ -63,8 +63,6 @@
 
 
 <style lang="scss" scoped>
-  @import "../styles/base";
-
   .content {
     color: $primary_color;
   }

--- a/src/views/TipCommentsView.vue
+++ b/src/views/TipCommentsView.vue
@@ -130,8 +130,6 @@
 
 
 <style lang="scss" scoped>
-  @import "../styles/base";
-
 .url__page{
   color: $light_font_color;
   font-size: .75rem;

--- a/src/views/TipsList.vue
+++ b/src/views/TipsList.vue
@@ -126,8 +126,6 @@
 
 
 <style lang="scss" scoped>
-  @import "../styles/base";
-
   .search__input__container{
     margin-bottom: .15rem;
     position: relative;

--- a/src/views/UserProfileView.vue
+++ b/src/views/UserProfileView.vue
@@ -261,8 +261,6 @@
 
 
 <style lang="scss" scoped>
-  @import "../styles/base";
-
   .profile__header{
     top: 0;
     z-index: 10;

--- a/vue.config.js
+++ b/vue.config.js
@@ -3,6 +3,17 @@ const FaviconsWebpackPlugin = require('favicons-webpack-plugin');
 
 module.exports = {
   lintOnSave: false,
+  css: {
+    loaderOptions: {
+      sass: {
+        // Global includes - will be prepended in every scss file (including components)
+        prependData: `
+          @import "@/styles/_variables";
+          @import "@/styles/_mixins";
+        `
+      }
+    }
+  },
   chainWebpack: config => config
     .plugin('favicons')
     .use(FaviconsWebpackPlugin, [{


### PR DESCRIPTION
closes #147 

Proposal after research is to use sass-loader automatically include variables and mixins, which are required by components.

Including of `base.scss` everywhere results in adding the behemot bootstrap framework for each of the tens components
