### PR TITLE
Hide browser's broken-image icon/border

### DIFF
--- a/src/components/tipRecords/TipRecord.vue
+++ b/src/components/tipRecords/TipRecord.vue
@@ -201,19 +201,38 @@ export default {
           background-color: $thumbnail_background_color;
           padding: 0;
           margin-left: 1rem;
-          border-top-right-radius: .5rem;
-          border-bottom-right-radius: .5rem;
+          border-radius: .5rem;
           margin-right: 1rem;
+          background-image: url("../../assets/headerLogo.svg");
+          background-position: 4rem center;
+          background-repeat: no-repeat;
+          overflow: hidden;
+          height: 9rem;
+
           &:hover{
             cursor: pointer;
           }
           img{
+            background-color: $thumbnail_background_color;
+            content: ' ';
             width: 50%;
             float: left;
-            height: 9rem;
-            border-top-left-radius: .5rem;
-            border-bottom-left-radius: .5rem;
             object-fit: cover;
+
+            // these styles apply to broken images
+            &:-moz-broken {
+              opacity: 0;
+            }
+            // chrome (Note: putting height on img will render a silver border)
+            &::after {
+              background: inherit;
+              content: ' ';
+              height: 18px;
+              left: 0;
+              position: absolute;
+              top: 0;
+              width: 18px;
+            }
           }
           span{
             color: $tip_note_color;

--- a/src/components/tipRecords/TipRecord.vue
+++ b/src/components/tipRecords/TipRecord.vue
@@ -218,6 +218,7 @@ export default {
             width: 50%;
             float: left;
             object-fit: cover;
+            min-height: 1px;
 
             // these styles apply to broken images
             &:-moz-broken {

--- a/src/views/TipCommentsView.vue
+++ b/src/views/TipCommentsView.vue
@@ -168,7 +168,6 @@ export default {
   }
   .comments__section{
     background-color: $actions_ribbon_background_color;
-    overflow-y: auto;
     padding: 1rem;
   }
   .no-results{


### PR DESCRIPTION
fix #189 

Note: styling this case is not really universal. I had to hack it.
Can't test it on Safari desktop.

also fixed a buggy scroll when you click on ❤ in profile-view -> tips

Also note: this is not for all images only for tip previews! Similar could be done for avatars for instance though there might need adjustments.