### PR TITLE
Fix: some tips w/o images not visualized

### DIFF
--- a/src/components/tipRecords/TipRecord.vue
+++ b/src/components/tipRecords/TipRecord.vue
@@ -98,7 +98,7 @@ export default {
       return this.tip.preview.responseUrl ? new URL(this.tip.preview.responseUrl).hostname : '';
     },
     tipPreviewImage() {
-      return this.isPreviewToBeVisualized(this.tip) ? Backend.getTipPreviewUrl(this.tip.preview.image) : '';
+      return this.isPreviewToBeVisualized(this.tip) && this.tip.preview.image !== null ? Backend.getTipPreviewUrl(this.tip.preview.image) : '';
     },
   },
   methods: {

--- a/src/components/tipRecords/TipRecord.vue
+++ b/src/components/tipRecords/TipRecord.vue
@@ -104,7 +104,7 @@ export default {
   methods: {
     isPreviewToBeVisualized(tip) {
       return typeof tip !== 'undefined' && tip !== null
-          && typeof tip.preview !== 'undefined' && tip.preview.image !== null
+          && typeof tip.preview !== 'undefined'
           && (
             (tip.preview.description !== null && tip.preview.description.length > 0)
             || (tip.preview.title !== null && tip.preview.title.length > 0)


### PR DESCRIPTION
Fix: some tips without images, but with valid description and title not being visualized.

- update isPreviewToBeVisualized check